### PR TITLE
Add cutoff rule for astrix and remove rule which could pull bullet points

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -56,7 +56,7 @@ class EmailMessage(object):
         The regexes cover English, Italian, Swedish, Finnish, Danish, German, Portuguese, Polish, French to date.
     """
     SENT_FROM_DEVICE_REGEX = re.compile(
-        r"(^--|^__|^-\w)"
+        r"(^--|^__|^\* \* \*)"
         r"|(^Sent from .{,50}$)"  # English
         r"|(^Sent using the mobile mail app)"  # English
         r"|(^Get Outlook for .{,50}$)"  # English

--- a/test/emails/email_with_quoted_text.txt
+++ b/test/emails/email_with_quoted_text.txt
@@ -1,0 +1,11 @@
+Hello,
+
+I'm good, and you?
+
+Tony
+
+>Hi Tony
+>
+>How are you today?
+>
+>Bob

--- a/test/emails/email_with_stars_signoff.txt
+++ b/test/emails/email_with_stars_signoff.txt
@@ -1,0 +1,11 @@
+Hi Joe,
+
+Thanks for getting back to me, that works fine.
+
+All the best,
+
+Jim
+
+* * *
+
+This is my email signoff


### PR DESCRIPTION
I noticed we have some emails that are separated by a "* * *" so I added a rule for that. I also noticed we have a rule on `r"-\w"` that would match things like a bullet point list, so I removed that. I also added a test to make sure it captures quoted text correctly.