### PR TITLE
Fix issue with matches at start of email

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -302,9 +302,8 @@ class EmailMessage(object):
         # Note we need to ignore the sent from if it is on the first line of the message
         end_of_first_line_index = body_clean.find("\n")
 
-        # If the signoff match is in the first line or 30 characters (if all on one line) of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
-        signoff_match_threshold = end_of_first_line_index if end_of_first_line_index != -1 else 30
-        signoff_matches = [match for match in signoff_matches if match.start() > signoff_match_threshold]
+        # If the signoff match is in the first line of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
+        signoff_matches = [match for match in signoff_matches if match.start() > end_of_first_line_index]
 
 
         sent_from_device_matches = []

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -303,7 +303,7 @@ class EmailMessage(object):
         end_of_first_line_index = body_clean.find("\n")
 
         # If the signoff match is in the first line or 30 characters (if all on one line) of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
-        signoff_match_threshold = end_of_first_line_index or 30
+        signoff_match_threshold = end_of_first_line_index if end_of_first_line_index != -1 else 30
         signoff_matches = [match for match in signoff_matches if match.start() > signoff_match_threshold]
 
 

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -299,11 +299,14 @@ class EmailMessage(object):
         # Find sign-off or sent from device match for unidecode copy
         signoff_matches = list(EmailMessage.EMAIL_SIGNOFF_REGEX.finditer(body_clean))
 
-        # If the signoff match is in the first 30 characters of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
-        signoff_matches = [match for match in signoff_matches if match.start() > 30]
-
         # Note we need to ignore the sent from if it is on the first line of the message
         end_of_first_line_index = body_clean.find("\n")
+
+        # If the signoff match is in the first line or 30 characters (if all on one line) of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
+        signoff_match_threshold = end_of_first_line_index or 30
+        signoff_matches = [match for match in signoff_matches if match.start() > signoff_match_threshold]
+
+
         sent_from_device_matches = []
         if end_of_first_line_index != -1:
             sent_from_device_matches = EmailMessage.SENT_FROM_DEVICE_REGEX.finditer(body_clean)

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -177,7 +177,7 @@ class EmailMessage(object):
         r"vielen dank im voraus|Mit freundlichen grussen|"
         r"saluti|Cordiali saluti|Distinti saluti|buona giornata|cordialmente|"
         r"o zi buna|o zi buna va urez|cu respect|cu stima|cu bine|toate cele bune|"
-        r"saludos cordiales|atentamente|un saludo)(.?)(,|\n))|"
+        r"saludos cordiales|atentamente|un saludo)(.{0,20})(,|\n))|"
         r"((thank you|thanks!?|thank you in advance|thanks in advance|merci|danke|"
         r"grazie|grazie mille|multumesc\s?|multumesc anticipat|multumesc frumos|gracias|muchos gracias)(,?!?\n))|"
         r"(Pozdrawiam.?|Z powazaniem|z pozdrowieniami)",
@@ -298,6 +298,9 @@ class EmailMessage(object):
 
         # Find sign-off or sent from device match for unidecode copy
         signoff_matches = list(EmailMessage.EMAIL_SIGNOFF_REGEX.finditer(body_clean))
+
+        # If the signoff match is in the first 30 characters of an email, it is likely a mistake (e.g. "Dear Mr. George Best,")
+        signoff_matches = [match for match in signoff_matches if match.start() > 30]
 
         # Note we need to ignore the sent from if it is on the first line of the message
         end_of_first_line_index = body_clean.find("\n")

--- a/email_reply_parser/version.py
+++ b/email_reply_parser/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.1'
+VERSION = '1.0.2'

--- a/test/emails/dutch_beste_example.txt
+++ b/test/emails/dutch_beste_example.txt
@@ -1,0 +1,5 @@
+Beste,
+
+How are you today?
+
+Timmy

--- a/test/emails/george_best.txt
+++ b/test/emails/george_best.txt
@@ -1,0 +1,9 @@
+Dear George Best,
+
+You are my favourite player
+
+All the best,
+
+Phil
+
+Here is some more text that won't be captured

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -322,5 +322,22 @@ class EmailMessageTest(unittest.TestCase):
         assert body.startswith('Hi,')
         assert body.endswith('Thanks')
 
+
+    def test_dont_cut_signature_at_start_of_email(self):
+        """
+        Some e-emails will start with things like "Dear Mr. Best,\n\nHow are you?" these can get parsed out at the end
+        of an email unless handled correctly. This test just makes sure that we handle those correctly.
+        """
+        first_message = self.get_email("george_best")
+        second_message = self.get_email("dutch_beste_example")
+
+        body_first_message = EmailReplyParser.cut_off_at_signature(first_message.text)
+        body_second_message = EmailReplyParser.cut_off_at_signature(second_message.text)
+
+        assert body_first_message.startswith("Dear George Best,")
+        assert body_first_message.endswith("Phil")
+        assert body_second_message.startswith("Beste,")
+        assert body_second_message.endswith("Timmy")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The first issue here appears to have been caused by an issue with the email reply parser where we parse the "Beste" bit at the start of an email as the end so this fixes that.

Imagine a case where someone start an email with "Hello Mr. Best," then we will think this is a signoff