### PR TITLE
Added New German Formats and Adjusted French Format

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -34,7 +34,7 @@ class EmailReplyParser(object):
         return EmailReplyParser.read(text).reply
 
     @staticmethod
-    def cut_off_at_signature(body: str, include: Optional[bool] = True, word_limit: Optional[int] = 100):
+    def cut_off_at_signature(body: str, include: Optional[bool] = True, word_limit: Optional[int] = 1000):
         """
         Remove the signature section from an email, and use the email Reply Parser to try to remove any
         "thread" content.
@@ -157,7 +157,8 @@ class EmailMessage(object):
         r"|Am (.{,120})\n?(.{,50})?schrieb(\s+)?::"  # German
         r"|Am (.{,120})schrieb(.{,50})?(\s+)?(:)?"  # German
         r"|(.{,50})?schrieb(.{,120})(\s+)?(:)?"  # German
-        r"|-(-*)?\s?(Ursprüngliche|Original|Forwarded).?(Nachricht|Message)\s?(-*)?-" #German/English
+        r"|(-(-*)?\s?(Ursprüngliche|Original).?(Nachricht|Message)\s?(-*)?-)" #German/English
+        r"|-(-*)?\s?Forwarded.?Message\s?(-*)?-" #German/English
         r"|ma (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|ti (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|pe (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
@@ -171,8 +172,8 @@ class EmailMessage(object):
         r"|No dia (.{,120})\n?(.{,50})?escreveu(\s+)?:"  # Portuguese
         r"|El (.{,120})\n?(.{,50})?escribio(\s+)?:"  # Spanish
         r"|El (.{,120})\n?(.{,50})?escribió(\s+)?:"  # Spanish
-        r"|Le (.{,120})\n?(.{,50})?ecrit(\s+)?(:)?"  # French
-        r"|Le (.{,120})\n?(.{,50})?écrit(\s+)?(:)?"  # French
+        r"|Le (.{,120})\n?(.{,50})?ecrit(\s+)?:?"  # French
+        r"|Le (.{,120})\n?(.{,50})?écrit(\s+)?:?"  # French
         r"|Dna (.{,120})\n?(.{,50})?napisala\(a\)(\s+)?:"  # Slovak
         r"|po (.{,120})\n?(.{,50})?napisal\(a\)(\s+)?:"  # Slovak
         r"|Dnia (.{,120})\n?(.{,50})?napisal\(a\)(\s+)?:" # Polish

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -100,6 +100,7 @@ class EmailMessage(object):
         r"|Am.*schrieb(.*?):$"  # German
         r"|Von.*gesendet(.*?)"  # German
         r"|.*[>|;] schrieb.*[0-9]{2}:[0-9]{2}:"  # German
+        r"|Ende der Kundennachricht"  # German
         r"|ma.*kirjoitti(.*?):$"  # Finnish
         r"|ti.*kirjoitti(.*?):$"  # Finnish
         r"|pe.*kirjoitti(.*?):$"  # Finnish
@@ -154,6 +155,9 @@ class EmailMessage(object):
         r"|tors (.{,120})\n?(.{,50})?skrev(\s+):"  # Norwegian
         r"|ons (.{,120})\n?(.{,50})?skrev(\s+):"  # Norwegian
         r"|Am (.{,120})\n?(.{,50})?schrieb(\s+)?::"  # German
+        r"|Am (.{,120})schrieb(.{,50})?(\s+)?(:)?"  # German
+        r"|(.{,50})?schrieb(.{,120})(\s+)?(:)?"  # German
+        r"|(-{,10})(\s*)?(Ursprüngliche|Original|Forwarded).?(Nachricht|Message)(\s*)?(-{,10})" #German/English
         r"|ma (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|ti (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|pe (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
@@ -167,8 +171,8 @@ class EmailMessage(object):
         r"|No dia (.{,120})\n?(.{,50})?escreveu(\s+)?:"  # Portuguese
         r"|El (.{,120})\n?(.{,50})?escribio(\s+)?:"  # Spanish
         r"|El (.{,120})\n?(.{,50})?escribió(\s+)?:"  # Spanish
-        r"|Le (.{,120})\n?(.{,50})?ecrit(\s+)?:"  # French
-        r"|Le (.{,120})\n?(.{,50})?écrit(\s+)?:"  # French
+        r"|Le (.{,120})\n?(.{,50})?ecrit(\s+)?(:)?"  # French
+        r"|Le (.{,120})\n?(.{,50})?écrit(\s+)?(:)?"  # French
         r"|Dna (.{,120})\n?(.{,50})?napisala\(a\)(\s+)?:"  # Slovak
         r"|po (.{,120})\n?(.{,50})?napisal\(a\)(\s+)?:"  # Slovak
         r"|Dnia (.{,120})\n?(.{,50})?napisal\(a\)(\s+)?:" # Polish
@@ -188,6 +192,7 @@ class EmailMessage(object):
         r"cordialement|très cordialement|bien cordialement|bien a vous|merci d'avance|d'avance merci|"
         r"Vielen Dank|Vielen Dank und LG|Herzliche Grusse|grussen\s?|grusse\s?|liebe Grusse\s?|"
         r"vielen dank im voraus|Mit freundlichen grussen|"
+        r"Mit freundlichen grüßen|Freundliche Grüße|"
         r"saluti|Cordiali saluti|Distinti saluti|buona giornata|cordialmente|"
         r"o zi buna|o zi buna va urez|cu respect|cu stima|cu bine|toate cele bune|"
         r"saludos cordiales|atentamente|un saludo)(.{0,20})(,|\n))|"
@@ -489,3 +494,4 @@ class Fragment(object):
     @property
     def content(self):
         return self._content.strip()
+

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -157,7 +157,7 @@ class EmailMessage(object):
         r"|Am (.{,120})\n?(.{,50})?schrieb(\s+)?::"  # German
         r"|Am (.{,120})schrieb(.{,50})?(\s+)?(:)?"  # German
         r"|(.{,50})?schrieb(.{,120})(\s+)?(:)?"  # German
-        r"|(-{,10})(\s*)?(Ursprüngliche|Original|Forwarded).?(Nachricht|Message)(\s*)?(-{,10})" #German/English
+        r"|-(-*)?\s?(Ursprüngliche|Original|Forwarded).?(Nachricht|Message)\s?(-*)?-" #German/English
         r"|ma (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|ti (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
         r"|pe (.{,120})\n?(.{,50})?kirjoitti(\s+)?:"  # Finnish
@@ -185,7 +185,7 @@ class EmailMessage(object):
         r"|Στις (.{,120})\n?(.{,50})?έγραψε(\s+)?:"  # Greek
         r")"
     )
-    MULTI_QUOTE_HDR_REGEX = re.compile(_MULTI_QUOTE_HDR_REGEX)
+    MULTI_QUOTE_HDR_REGEX = re.compile(_MULTI_QUOTE_HDR_REGEX,flags=re.IGNORECASE)
 
     EMAIL_SIGNOFF_REGEX = re.compile(
         r"((regards|kind regards|warm regards|best regards|best wishes|sincerely|best|cheers|"

--- a/test/emails/forwarded_message_french.txt
+++ b/test/emails/forwarded_message_french.txt
@@ -1,0 +1,34 @@
+Bonjour,
+Je suis navrée mais veuillez trouver ci-joint les défauts découverts lors
+de l'ouverture du colis de mon Brasero.
+Les détails de la commande sont dans le mail ci-dessous.
+Quelles solutions me proposez-vous ?
+Je vous remercie pour la considération que vous porterez à ma réclamation.
+Je reste disponible
+Bonne fin de journée
+---------- Forwarded message ---------
+De : Blumfeldt FR
+Date: lun. 15 avr. 2024, 08:20
+Subject: Votre commande sur Blumfeldt (#220125)
+To:
+Merci pour votre commande !
+Si vous avez des questions, n'hésitez pas à nous écrire un email à
+info@blumfeldt.fr!
+Veuillez noter : il s'agit d'une confirmation de commande préliminaire !
+Vous recevrez une confirmation de commande finale ainsi que votre numéro de
+commande.
+N° Commande
+Produit
+Prix unitaire
+Quantité
+TVA
+Total
+Merano Circolo brasero 3 en 1 avec fonction barbecue utilisable comme
+table diamètre 87 cm
+N° produit::
+259,99 €
+1
+20%
+259,99 €
+plus d'information
+Contact

--- a/test/emails/french_signoff.txt
+++ b/test/emails/french_signoff.txt
@@ -1,0 +1,20 @@
+Je ne peux pas avoir accès à ma facture
+N cde XXXXXXX
+N colis XXXXXXX
+Il est signalé site innaxecible
+Le mar. 30 avr. 2024, 11:53, Klarstein Service  a écrit :
+
+
+
+    Bonjour Daniel,
+
+    profitez bien votre commande ! Vous trouverez ci-joint votre facture pour
+    la commande XXXXXXX au format PDF. Veuillez conserver ce document.
+
+    Pour lire et imprimer le document PDF, vous avez besoin du programme
+    Acrobat Reader d'Adobe. Vous pouvez le télécharger ici
+
+    gratuitement.
+
+
+    Meilleures salutations et à bientôt,

--- a/test/emails/german_signoff.txt
+++ b/test/emails/german_signoff.txt
@@ -1,0 +1,7 @@
+Guten Tag, habe gerade mit voller Vorfreude den Gusseisentopf ausgepackt. Leider musste ich schon beim ersten mal hinsehen feststellen das er einige „Macken“ aufweist. Siehe Bilder im Anhang. Kann mir nicht vorstellen das jeder neue Topf so bei ihnen aussieht? Ausbesserungen sieht man sehr gut an einigen Stellen. Sehr schade.
+Vielen Dank im Voraus.
+Mit freundlichen Grüßen
+Am 20.06.24 um 16:20 schrieb Klarstein Deutschland - Amazon Payments
+Von: "Klarstein Deutschland - Amazon Payments"
+Datum: 20. Juni 2024
+An: [E-Mail-Adresse entfernt]

--- a/test/emails/german_signoff_2.txt
+++ b/test/emails/german_signoff_2.txt
@@ -1,0 +1,7 @@
+Hallo, leider ist die Ware beschädigt! Wir möchten das, das Paket wieder
+abgeholt wird!
+Freundliche Grüße
+blumfeldt  schrieb am Do. 20. Juni 2024 um 14:49:
+
+    Deine Bestellnummer: XXXXXXXX
+    Deine Tracking-Nimmer: XXXXXXX

--- a/test/emails/original_message_german.txt
+++ b/test/emails/original_message_german.txt
@@ -8,3 +8,13 @@ Von: Klarstein
 Betreff: Deine Bestellung von Klarstein Wurde Zugestellt - Viel Spaß damit!
 Datum: 21.06.2024, 10:47 Uhr
 An:
+Deine Bestellnummer: 0405876846 Deine Tracking-Nimmer: 01475111007880
+Deine Bestellnummer: 0405876846
+Deine Tracking-Nummer: 01475111007880
+Hallo Monika,
+tolle Neuigkeiten! DPD hat die erfolgreiche Zustellung deiner Bestellung
+von Klarstein bestätigt.
+Wir hoffen, dass dein neuer Kauf Freude und Zufriedenheit in dein Zuhause
+bringt.
+Wenn du uns etwas mitteilen möchtest oder Fragen hast, ist unser Team für
+dich da und hilft dir gerne weiter.

--- a/test/emails/original_message_german.txt
+++ b/test/emails/original_message_german.txt
@@ -1,0 +1,10 @@
+Guten Tag.
+Leider ist das Paket beschädigt angekommen. Die Tür hängt schief. Die
+Scharnier ist gebrochen.
+Anbei Fotos
+Mit freundlichen Grüßen
+-----Original-Nachricht-----
+Von: Klarstein
+Betreff: Deine Bestellung von Klarstein Wurde Zugestellt - Viel Spaß damit!
+Datum: 21.06.2024, 10:47 Uhr
+An:

--- a/test/emails/original_message_german_2.txt
+++ b/test/emails/original_message_german_2.txt
@@ -1,0 +1,16 @@
+Hallo,Welches Dokument
+Mit freundlichen Grüßen
+-------- Ursprüngliche Nachricht --------Von: "electronic.star Service"  Datum: 07.08.24  18:46  (GMT+01:00) An: Betreff: Informationen zur Rücksendung deiner Bestellung bei Electronic-Star
+
+Die Rechnungsnummer zu deiner Reklamation:
+Aktueller Status: Angenommen zur Rücksendung
+Hallo Martin,
+du möchtest einen Artikel zurücksenden - wir kümmern uns um eine schnelle und reibungslose Abwicklung!
+Bitte drucke dafür dieses Dokument aus und lege es deiner Rücksendung bei.
+Um einen Termin für die Abholung zu vereinbaren, wird die Spedition Dachser (pickup) dich unter der in deinem Kundenkonto hinterlegten Nummer anrufen:+436503350845.
+Solltest du unter dieser Nummer nicht erreichbar sein, kontaktiere bitte unseren Kundenservice und teile uns eine alternative Nummer mit.
+Sende uns den Artikel vollständig inklusive aller Zubehörteile zurück.
+Festgestellte Beschädigungen können zu Wertabzug führen. Deshalb denke bitte auch an eine ausreichende und transportsichere Umverpackung wenn nötig.
+Die durchschnittliche Bearbeitungszeit der Retoure nach Eingang im Lager beträgt 5 bis 7 Werktage.
+Viele Grüße aus Berlin,
+dein Team von Electronic-Star.

--- a/test/emails/test_word_limit.txt
+++ b/test/emails/test_word_limit.txt
@@ -1,0 +1,22 @@
+Bonjour,
+inadmissible ....et vous écrivez que vos clients sont 100 % satisfaits
+....Ce n'est pas mon cas.
+Quelle société êtes vous donc ?
+Vous faites de la publicité sur votre site avec offre de remboursement
+de 22 %
+Je passe commande, paie avec PayPal.
+Vous m' envoyez une confirmation de commande 0405623877 par mail et vous
+me confirmez, à nouveau, la commande par message du 30/04/2024
+Et aujourd'hui, vous annulez la commande suite "erreur de système".
+La raison de cette annulation ( "erreur système") n'apparait pas dans
+vos conditions générales.Vous ne pouvez donc pas annuler cette commande.
+( voila ce qui écris dans vos conditions générales : "Occasionnellement,
+il peut arriver qu’une erreur se produise et que des articles soient
+vendus à un prix incorrect ou, que leur description présente une fausse
+information. Dans cette situation, nous ne serons pas obligés de fournir
+les articles au prix incorrect, en accord avec une fausse description,
+et nous nous réservons le droit d’annuler la vente pour ces motifs")
+Je vous demande donc de valider ma commande.
+Dans le cas contraire , je ferai appel à mon assistance juridique et en
+informerai mes collègues de la DGCCRF
+Cdt

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -389,6 +389,10 @@ class EmailMessageTest(unittest.TestCase):
         assert body_second_message.endswith('Mit freundlichen Grüßen')
         assert body_third_message.endswith('Bonne fin de journée')
 
+    def test_word_limit (self):
+        test = self.get_email('test_word_limit')
+        body = EmailReplyParser.cut_off_at_signature(test.text, include=True, word_limit=500)
+        assert body.endswith('Cdt')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -350,5 +350,36 @@ class EmailMessageTest(unittest.TestCase):
         assert body_second_message.startswith("Beste,")
         assert body_second_message.endswith("Timmy")
 
+    def test_french_sign_off(self):
+        """
+        Tests that we're parsing the 'On Jan 31 X wrote:' correctly in french.
+        """
+
+        message = self.get_email('french_signoff')
+        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
+        assert body.endswith('Il est signalé site innaxecible')
+
+    def test_german_sign_off(self):
+        """
+        Tests that we're parsing the 'On Jan 31 X wrote:' correctly in german.
+        """
+
+        first_message = self.get_email('german_signoff')
+        second_message = self.get_email('german_signoff_2')
+        body_first_message = EmailReplyParser.cut_off_at_signature(first_message.text, include=True)
+        body_second_message = EmailReplyParser.cut_off_at_signature(second_message.text, include=True)
+        assert body_first_message.endswith('Mit freundlichen Grüßen')
+        assert body_second_message.endswith('Freundliche Grüße')
+
+    def test_orginal_message_sign_off(self):
+        """
+        Tests that we're parsing the ---- Original Message ---- correctly in german.
+        """
+        message = self.get_email('original_message_german')
+        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
+        assert body.endswith('Mit freundlichen Grüßen')
+
+
 if __name__ == '__main__':
     unittest.main()
+

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -373,11 +373,21 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_orginal_message_sign_off(self):
         """
-        Tests that we're parsing the ---- Original Message ---- correctly in german.
+        Tests that we're parsing the following correctly in german/french/english:
+         ---- Original Message ----
+        --------- Ursprungliche Nachricht ---------
+         ----Original-Nachricht----
+         ---------- Forwarded message ---------
         """
-        message = self.get_email('original_message_german')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body.endswith('Mit freundlichen Grüßen')
+        first_message = self.get_email('original_message_german')
+        second_message = self.get_email('original_message_german_2')
+        third_message = self.get_email('forwarded_message_french')
+        body_first_message = EmailReplyParser.cut_off_at_signature(first_message.text, include=True)
+        body_second_message = EmailReplyParser.cut_off_at_signature(second_message.text, include=True)
+        body_third_message = EmailReplyParser.cut_off_at_signature(third_message.text, include=True)
+        assert body_first_message.endswith('Mit freundlichen Grüßen')
+        assert body_second_message.endswith('Mit freundlichen Grüßen')
+        assert body_third_message.endswith('Bonne fin de journée')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added new formats for German.

In`QUOTE_HDR_REGEX`:
-format for parsing German. End of customer message: *'Ende der Kundennachricht'*

In `_MULTI_QUOTE_HDR_REGEX`:
- format for parsing German. *"Am 21.06.2024 um 09:49 schrieb X"*
- format for parsing German. *"X chrieb am Do. 20. Juni 2024 um 14:49:"*
- format for parsing German. Original message: *"-------- Ursprüngliche Nachricht --------"*
- format for parsing English/German. Forwarded message: *"-------- Forwarded message --------"*

In `EMAIL_SIGNOFF_REGEX`:
- format for parsing German. *'Mit freundlichen Grüßen'*
- format for parsing German. *'Freundliche Grüße'*

Also adjusted for cases when a colon isn't used for the french format in `_MULTI_QUOTE_HDR_REGEX`.