### PR TITLE
Refactor tests

### DIFF
--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import time
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from email_reply_parser import EmailReplyParser
@@ -9,8 +10,7 @@ from email_reply_parser import EmailReplyParser
 
 def get_email(name):
     """Return EmailMessage instance, utility function"""
-    with open('emails/%s.txt' % name) as f:
-        text = f.read()
+    text = Path(f'emails/{name}.txt').read_text()
     return EmailReplyParser.read(text)
 
 

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -170,36 +170,6 @@ class EmailMessageTest(unittest.TestCase):
 
         self.assertEqual(body, "Yes that would be fine")
 
-    # -------------------- LANGUAGES -------------------- #
-
-    def test_include_signature_true(self):
-        # Test that the cut_off_at_signature function ends an email after the sign-off when include = True
-        message_english = get_email('email_signature')
-        message_german = get_email('email_german')
-        message_french = get_email('email_french')
-
-        body_english = EmailReplyParser.cut_off_at_signature(message_english.text, include=True, word_limit=100)
-        body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=True, word_limit=100)
-        body_french = EmailReplyParser.cut_off_at_signature(message_french.text, include=True, word_limit=100)
-
-        self.assertTrue(body_english.endswith('Kind regards,\n\nPerrin Aybara'))
-        self.assertTrue(body_german.endswith('Mit freundlichen Grüßen,\n\nLukas'))
-        self.assertTrue(body_french.endswith('Bien à vous,\n\nNicolette Baudelaire'))
-
-    def test_include_signature_false(self):
-        # Test that the cut_off_at_signature function ends an email before the sign-off when include = False
-        message_english = get_email('email_signature')
-        message_german = get_email('email_german')
-        message_french = get_email('email_french')
-
-        body_english = EmailReplyParser.cut_off_at_signature(message_english.text, include=False, word_limit=100)
-        body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=False, word_limit=100)
-        body_french = EmailReplyParser.cut_off_at_signature(message_french.text, include=False, word_limit=100)
-
-        self.assertTrue(body_english.endswith('email cut-off point.'))
-        self.assertTrue(body_german.endswith('November vornehmen.'))
-        self.assertTrue(body_french.endswith("s'il vous plaît?"))
-
     def test_word_limit(self):
         # Test that a long email cuts off after the default or given word limit
         message = get_email('long_passage')
@@ -211,123 +181,10 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue(body_short.endswith('TEN!'))
         self.assertTrue(body_long.endswith('FIVE HUNDRED IS HERE!'))
 
-    def test_clean_email_portuguese(self):
-        # Test Portuguese regex
-        message = get_email('email_portuguese')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
-        self.assertTrue(body.endswith("Cumprimentos\nPedro Mota"))
-
-    def test_clean_email_french(self):
-        # Test Portuguese regex
-        message = get_email('email_french_accent_sent_on')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
-        self.assertEqual(body, "Bonjour, ca va bien!")
-
-    def test_remove_SIG_REGEX_end(self):
-        # Test that any "Sent from iPhone" messages are removed at the end of an email
-        message_french = get_email('email_iphone_french')
-        message_portuguese = get_email('email_iphone_portuguese')
-        message_polish = get_email('email_iphone_polish')
-        message_finnish = get_email('email_iphone_finnish')
-
-        body_french = EmailReplyParser.cut_off_at_signature(message_french.text)
-        body_portuguese = EmailReplyParser.cut_off_at_signature(message_portuguese.text)
-        body_polish = EmailReplyParser.cut_off_at_signature(message_polish.text)
-        body_finnish = EmailReplyParser.cut_off_at_signature(message_finnish.text)
-
-        self.assertTrue(body_french.endswith("Au revoir,\n\nKelsier"))
-        self.assertTrue(body_portuguese.endswith("Adeus,\n\nOtis"))
-        self.assertTrue(body_polish.endswith("Do widzenia,\n\nTriss"))
-        self.assertTrue(body_finnish.endswith("Hyvästi,\n\nTorin"))
-
-    def test_remove_SIG_REGEX_start(self):
-        # Test that any "Sent from iPhone" messages are removed at the beginning of an email
-        message_english = get_email('email_iphone_start')
-        message_german = get_email('email_iphone_start_german')
-        body_english = EmailReplyParser.cut_off_at_signature(message_english.text)
-        body_german = EmailReplyParser.cut_off_at_signature(message_german.text)
-        self.assertTrue(body_english.startswith('Hi,\n\nCase where the'))
-        self.assertTrue(body_german.startswith('Hallo,\n\nFall, in dem das'))
-
-
-    def test_parse_response_headers(self):
-        """
-        Tests that we are parsing out email response headers correctly for multiple languages
-        """
-        message = get_email('email_polish_1')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
-
-        message = get_email('email_polish_2')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
-
-        message = get_email('email_polish_3')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
-
-        message = get_email('email_polish_4')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
-
-        message = get_email('email_greek_1')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body.endswith("Από τον Άδη"))
-
-        message = get_email('email_malformed_thread_header')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body.endswith("que cet e-mail est analysé correctement"))
-
-        message = get_email('email_with_two_headers')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "This is the main content")
-
-        message = get_email('email_portuguese_1')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "This is the main body")
-
-        message = get_email('email_portuguese_2')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "Here is the actual email")
-
-        message = get_email('email_portuguese_3')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body.startswith("This is a test"))
-        self.assertTrue(body.endswith("This should be included"))
-
-        message = get_email('email_romanian_1')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "This is the actual email")
-
-        message = get_email('email_german_2')
-        body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertEqual(body, "This is a german email")
-
-
-    def test_sent_from_device_in_thread_languages(self):
-        """
-        Tests that if the thread becomes malformed we will be able to parse out the correct part if a sent from device is present
-        """
-        message_english = get_email("sent_from_device_in_thread_english")
-        message_hungarian = get_email("sent_from_device_in_thread_hungarian")
-        message_dutch = get_email("sent_from_device_in_thread_dutch")
-        message_romanian = get_email("sent_from_device_in_thread_romanian")
-
-        body_english = EmailReplyParser.cut_off_at_signature(message_english.text)
-        body_hungarian = EmailReplyParser.cut_off_at_signature(message_hungarian.text)
-        body_dutch = EmailReplyParser.cut_off_at_signature(message_dutch.text)
-        body_romanian = EmailReplyParser.cut_off_at_signature(message_romanian.text)
-
-        self.assertEqual(body_english, "Yes that would be fine")
-        self.assertEqual(body_hungarian, "Yes that would be fine")
-        self.assertEqual(body_dutch, "Yes that would be fine")
-        self.assertEqual(body_romanian, "Yes that would be fine")
-
     def test_remove_non_alphabetic_signature_patter(self):
         """
         Tests that we we pick up things like --- and  * * * as signatures and ignore bullets
         """
-
         message_stars_signoff = get_email("email_with_stars_signoff")
         body = EmailReplyParser.cut_off_at_signature(message_stars_signoff.text)
         self.assertTrue(body.endswith("Jim"))
@@ -346,6 +203,114 @@ class EmailMessageTest(unittest.TestCase):
         body = EmailReplyParser.cut_off_at_signature(message.text)
         self.assertTrue(body.endswith("Tony"))
 
+    # -------------------- LANGUAGES -------------------- #
+
+    def test_include_signature_true(self):
+        # Test that the cut_off_at_signature function ends an email after the sign-off when include = True
+        correct_ending = {
+            # File_name: Correct Ending
+            'email_signature': 'Kind regards,\n\nPerrin Aybara',
+            'email_german': 'Mit freundlichen Grüßen,\n\nLukas',
+            'email_french': 'Bien à vous,\n\nNicolette Baudelaire',
+        }
+
+        for language, phrase in correct_ending.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=True, word_limit=100)
+            self.assertTrue(body.endswith(phrase))
+
+    def test_include_signature_false(self):
+        # Test that the cut_off_at_signature function ends an email before the sign-off when include = False
+        correct_ending = {
+            # File_name: Correct Ending
+            'email_signature': 'email cut-off point.',
+            'email_german': 'November vornehmen.',
+            'email_french': 's\'il vous plaît?',
+        }
+
+        for language, phrase in correct_ending.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
+            self.assertTrue(body.endswith(phrase))
+
+    def test_remove_SIG_REGEX_end(self):
+        # Test that any "Sent from iPhone" messages are removed at the end of an email
+        correct_ending = {
+            'email_iphone_french': 'Au revoir,\n\nKelsier',
+            'email_iphone_portuguese': 'Adeus,\n\nOtis',
+            'email_iphone_polish': 'Do widzenia,\n\nTriss',
+            'email_iphone_finnish': 'Hyvästi,\n\nTorin',
+        }
+
+        for language, phrase in correct_ending.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
+            self.assertTrue(body.endswith(phrase))
+
+    def test_remove_SIG_REGEX_start(self):
+        # Test that any "Sent from iPhone" messages are removed at the beginning of an email
+        correct_start = {
+        'email_iphone_start': 'Hi,\n\nCase where the',
+        'email_iphone_start_german': 'Hallo,\n\nFall, in dem das',
+        }
+
+        for language, phrase in correct_start.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
+            self.assertTrue(body.startswith(phrase))
+
+    def test_parse_response_headers_equal(self):
+        """
+        Parsing out email reponse headers for multiple languages. Checks for equality.
+        """
+        correct_phrase = {
+            'email_polish_1': 'Ten tekst powinien pojawić się w treści',
+            'email_polish_2': 'Ten tekst powinien pojawić się w treści',
+            'email_polish_3': 'Ten tekst powinien pojawić się w treści',
+            'email_polish_4': 'Ten tekst powinien pojawić się w treści',
+            'email_with_two_headers': 'This is the main content',
+            'email_portuguese_1': 'This is the main body',
+            'email_portuguese_2': 'Here is the actual email',
+            'email_romanian_1': 'This is the actual email',
+            'email_german_2': 'This is a german email',
+        }
+
+        for language, phrase in correct_phrase.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
+            self.assertEqual(body, phrase)
+
+    def test_parse_response_headers_endswith(self):
+        """
+        Parsing out email reponse headers for multiple languages. Checks for correct ending.
+        """
+        correct_ending = {
+            'email_malformed_thread_header': 'que cet e-mail est analysé correctement',
+            'email_greek_1': 'Από τον Άδη',
+            'email_portuguese_3': 'This should be included',
+        }
+
+        for language, phrase in correct_ending.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
+            self.assertTrue(body.endswith(phrase))
+
+    def test_sent_from_device_in_thread_languages(self):
+        """
+        Tests that if the thread becomes malformed we will be able to parse out the correct part if a sent from device is present
+        """
+        correct_phrase = {
+            'sent_from_device_in_thread_english': 'Yes that would be fine',
+            'sent_from_device_in_thread_hungarian': 'Yes that would be fine',
+            'sent_from_device_in_thread_dutch': 'Yes that would be fine',
+            'sent_from_device_in_thread_romanian': 'Yes that would be fine',
+        }
+
+        for language, phrase in correct_phrase.items():
+            message = get_email(language)
+            body = EmailReplyParser.cut_off_at_signature(message.text)
+            self.assertEqual(body, phrase)
+
     def test_spanish_signoff(self):
         """
         Tests that we're parsing the 'On Jan 31 X wrote:' correctly in Spanish.
@@ -353,6 +318,18 @@ class EmailMessageTest(unittest.TestCase):
         message = get_email('spanish_signoff')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         self.assertTrue(body.endswith('Salud'))
+
+    def test_clean_email_portuguese(self):
+        # Test Portuguese regex
+        message = get_email('email_portuguese')
+        body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
+        self.assertTrue(body.endswith("Cumprimentos\nPedro Mota"))
+
+    def test_clean_email_french(self):
+        # Test French regex
+        message = get_email('email_french_accent_sent_on')
+        body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
+        self.assertEqual(body, "Bonjour, ca va bien!")
 
 
 if __name__ == '__main__':

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -25,7 +25,6 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_multiline_reply_headers(self):
         message = self.get_email('email_1_6')
-        print(message)
         self.assertTrue('I get' in message.fragments[0].content)
         self.assertTrue('Sent' in message.fragments[1].content)
 

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -31,13 +31,13 @@ class EmailMessageTest(unittest.TestCase):
             [False, True],
             [f.hidden for f in message.fragments]
         )
-        self.assertTrue("folks" in message.fragments[0].content)
-        self.assertTrue("riak-users" in message.fragments[1].content)
+        self.assertIn("folks", message.fragments[0].content)
+        self.assertIn("riak-users", message.fragments[1].content)
 
     def test_multiline_reply_headers(self):
         message = get_email('email_1_6')
-        self.assertTrue('I get' in message.fragments[0].content)
-        self.assertTrue('Sent' in message.fragments[1].content)
+        self.assertIn('I get', message.fragments[0].content)
+        self.assertIn('Sent', message.fragments[1].content)
 
     def test_complex_body_with_one_fragment(self):
         message = get_email('email_1_5')
@@ -63,11 +63,11 @@ class EmailMessageTest(unittest.TestCase):
             [f.hidden for f in message.fragments]
         )
 
-        self.assertTrue('--' in message.fragments[1].content)
+        self.assertIn('--', message.fragments[1].content)
 
     def test_deals_with_windows_line_endings(self):
         msg = get_email('email_1_7')
-        self.assertTrue(':+1:' in msg.fragments[0].content)
+        self.assertIn(':+1:', msg.fragments[0].content)
 
     def test_reply_from_gmail(self):
         message = get_email_text('email_gmail')
@@ -90,19 +90,19 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_sent_from_iphone(self):
         message = get_email_text('email_iPhone')
-        self.assertTrue("Sent from my iPhone" not in EmailReplyParser.parse_reply(message))
+        self.assertNotIn("Sent from my iPhone", EmailReplyParser.parse_reply(message))
 
     def test_email_one_is_not_on(self):
         message = get_email_text('email_one_is_not_on')
-        self.assertTrue(
-            "On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(message)
+        self.assertNotIn(
+            "On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:", EmailReplyParser.parse_reply(message)
         )
 
     def test_partial_quote_header(self):
         message = get_email('email_partial_quote_header')
-        self.assertTrue("On your remote host you can run:" in message.reply)
-        self.assertTrue("telnet 127.0.0.1 52698" in message.reply)
-        self.assertTrue("This should connect to TextMate" in message.reply)
+        self.assertIn("On your remote host you can run:", message.reply)
+        self.assertIn("telnet 127.0.0.1 52698", message.reply)
+        self.assertIn("This should connect to TextMate", message.reply)
 
     def test_email_headers_no_delimiter(self):
         message = get_email('email_headers_no_delimiter')
@@ -168,7 +168,7 @@ class EmailMessageTest(unittest.TestCase):
         message = get_email("sent_from_device_in_thread")
         body = EmailReplyParser.cut_off_at_signature(message.text)
 
-        self.assertTrue(body == "Yes that would be fine")
+        self.assertEqual(body, "Yes that would be fine")
 
     # -------------------- LANGUAGES -------------------- #
 
@@ -221,7 +221,7 @@ class EmailMessageTest(unittest.TestCase):
         # Test Portuguese regex
         message = get_email('email_french_accent_sent_on')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
-        self.assertTrue(body == "Bonjour, ca va bien!")
+        self.assertEqual(body, "Bonjour, ca va bien!")
 
     def test_remove_SIG_REGEX_end(self):
         # Test that any "Sent from iPhone" messages are removed at the end of an email
@@ -256,19 +256,19 @@ class EmailMessageTest(unittest.TestCase):
         """
         message = get_email('email_polish_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
+        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
+        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
+        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_4')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
+        self.assertEqual(body, "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_greek_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
@@ -280,15 +280,15 @@ class EmailMessageTest(unittest.TestCase):
 
         message = get_email('email_with_two_headers')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "This is the main content")
+        self.assertEqual(body, "This is the main content")
 
         message = get_email('email_portuguese_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "This is the main body")
+        self.assertEqual(body, "This is the main body")
 
         message = get_email('email_portuguese_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "Here is the actual email")
+        self.assertEqual(body, "Here is the actual email")
 
         message = get_email('email_portuguese_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
@@ -297,11 +297,11 @@ class EmailMessageTest(unittest.TestCase):
 
         message = get_email('email_romanian_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "This is the actual email")
+        self.assertEqual(body, "This is the actual email")
 
         message = get_email('email_german_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        self.assertTrue(body == "This is a german email")
+        self.assertEqual(body, "This is a german email")
 
 
     def test_sent_from_device_in_thread_languages(self):
@@ -318,10 +318,10 @@ class EmailMessageTest(unittest.TestCase):
         body_dutch = EmailReplyParser.cut_off_at_signature(message_dutch.text)
         body_romanian = EmailReplyParser.cut_off_at_signature(message_romanian.text)
 
-        self.assertTrue(body_english == "Yes that would be fine")
-        self.assertTrue(body_hungarian == "Yes that would be fine")
-        self.assertTrue(body_dutch == "Yes that would be fine")
-        self.assertTrue(body_romanian == "Yes that would be fine")
+        self.assertEqual(body_english, "Yes that would be fine")
+        self.assertEqual(body_hungarian, "Yes that would be fine")
+        self.assertEqual(body_dutch, "Yes that would be fine")
+        self.assertEqual(body_romanian, "Yes that would be fine")
 
     def test_remove_non_alphabetic_signature_patter(self):
         """

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -127,9 +127,9 @@ class EmailMessageTest(unittest.TestCase):
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=True, word_limit=100)
         body_french = EmailReplyParser.cut_off_at_signature(message_french.text, include=True, word_limit=100)
 
-        assert body_english.endswith('Kind regards,\n\nPerrin Aybara')
-        assert body_german.endswith('Mit freundlichen Grüßen,\n\nLukas')
-        assert body_french.endswith('Bien à vous,\n\nNicolette Baudelaire')
+        self.assertTrue(body_english.endswith('Kind regards,\n\nPerrin Aybara'))
+        self.assertTrue(body_german.endswith('Mit freundlichen Grüßen,\n\nLukas'))
+        self.assertTrue(body_french.endswith('Bien à vous,\n\nNicolette Baudelaire'))
 
     def test_include_signature_false(self):
         # Test that the cut_off_at_signature function ends an email before the sign-off when include = False
@@ -141,9 +141,9 @@ class EmailMessageTest(unittest.TestCase):
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=False, word_limit=100)
         body_french = EmailReplyParser.cut_off_at_signature(message_french.text, include=False, word_limit=100)
 
-        assert body_english.endswith('email cut-off point.')
-        assert body_german.endswith('November vornehmen.')
-        assert body_french.endswith("s'il vous plaît?")
+        self.assertTrue(body_english.endswith('email cut-off point.'))
+        self.assertTrue(body_german.endswith('November vornehmen.'))
+        self.assertTrue(body_french.endswith("s'il vous plaît?"))
 
     def test_word_limit(self):
         # Test that a long email cuts off after the default or given word limit
@@ -152,21 +152,21 @@ class EmailMessageTest(unittest.TestCase):
         body_short = EmailReplyParser.cut_off_at_signature(message.text, word_limit=10)  # Less than default
         body_long = EmailReplyParser.cut_off_at_signature(message.text, word_limit=500)  # More than default
 
-        assert body_default_limit.endswith('"HERE IS ONE HUNDRED!"')
-        assert body_short.endswith('TEN!')
-        assert body_long.endswith('FIVE HUNDRED IS HERE!')
+        self.assertTrue(body_default_limit.endswith('"HERE IS ONE HUNDRED!"'))
+        self.assertTrue(body_short.endswith('TEN!'))
+        self.assertTrue(body_long.endswith('FIVE HUNDRED IS HERE!'))
 
     def test_clean_email_portuguese(self):
         # Test Portuguese regex
         message = get_email('email_portuguese')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
-        assert body.endswith("Cumprimentos\nPedro Mota")
+        self.assertTrue(body.endswith("Cumprimentos\nPedro Mota"))
 
     def test_clean_email_french(self):
         # Test Portuguese regex
         message = get_email('email_french_accent_sent_on')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
-        assert body == "Bonjour, ca va bien!"
+        self.assertTrue(body == "Bonjour, ca va bien!")
 
     def test_clean_email_content_no_change(self):
         # Ensure that a short email with no reply and no signature doesn't change
@@ -178,13 +178,13 @@ class EmailMessageTest(unittest.TestCase):
         # Check that an email that continues after the sign-off (without being a header or reply) cuts off at signature
         message = get_email('email_continue_after_signoff')
         body = EmailReplyParser.cut_off_at_signature(message.text)
-        assert body.endswith('Tom Bombadil')
+        self.assertTrue(body.endswith('Tom Bombadil'))
 
     def test_keep_newlines_when_no_signoff(self):
         # Test that when there is no sign-off message detected at the end, the newlines/spacing are not changed
         message = get_email('email_no_signature')
         body = EmailReplyParser.cut_off_at_signature(message.text)
-        assert body.endswith("Let's see if it works.\n\nK")
+        self.assertTrue(body.endswith("Let's see if it works.\n\nK"))
 
     def test_remove_SIG_REGEX_end(self):
         # Test that any "Sent from iPhone" messages are removed at the end of an email
@@ -198,10 +198,10 @@ class EmailMessageTest(unittest.TestCase):
         body_polish = EmailReplyParser.cut_off_at_signature(message_polish.text)
         body_finnish = EmailReplyParser.cut_off_at_signature(message_finnish.text)
 
-        assert body_french.endswith("Au revoir,\n\nKelsier")
-        assert body_portuguese.endswith("Adeus,\n\nOtis")
-        assert body_polish.endswith("Do widzenia,\n\nTriss")
-        assert body_finnish.endswith("Hyvästi,\n\nTorin")
+        self.assertTrue(body_french.endswith("Au revoir,\n\nKelsier"))
+        self.assertTrue(body_portuguese.endswith("Adeus,\n\nOtis"))
+        self.assertTrue(body_polish.endswith("Do widzenia,\n\nTriss"))
+        self.assertTrue(body_finnish.endswith("Hyvästi,\n\nTorin"))
 
     def test_remove_SIG_REGEX_start(self):
         # Test that any "Sent from iPhone" messages are removed at the beginning of an email
@@ -209,8 +209,8 @@ class EmailMessageTest(unittest.TestCase):
         message_german = get_email('email_iphone_start_german')
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text)
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text)
-        assert body_english.startswith('Hi,\n\nCase where the')
-        assert body_german.startswith('Hallo,\n\nFall, in dem das')
+        self.assertTrue(body_english.startswith('Hi,\n\nCase where the'))
+        self.assertTrue(body_german.startswith('Hallo,\n\nFall, in dem das'))
 
 
     def test_parse_response_headers(self):
@@ -219,54 +219,52 @@ class EmailMessageTest(unittest.TestCase):
         """
         message = get_email('email_polish_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "Ten tekst powinien pojawić się w treści"
+        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "Ten tekst powinien pojawić się w treści"
+        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "Ten tekst powinien pojawić się w treści"
+        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_polish_4')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "Ten tekst powinien pojawić się w treści"
+        self.assertTrue(body == "Ten tekst powinien pojawić się w treści")
 
         message = get_email('email_greek_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body.endswith("Από τον Άδη")
+        self.assertTrue(body.endswith("Από τον Άδη"))
 
         message = get_email('email_malformed_thread_header')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-
-        assert body.endswith("que cet e-mail est analysé correctement")
+        self.assertTrue(body.endswith("que cet e-mail est analysé correctement"))
 
         message = get_email('email_with_two_headers')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-
-        assert body == "This is the main content"
+        self.assertTrue(body == "This is the main content")
 
         message = get_email('email_portuguese_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "This is the main body"
+        self.assertTrue(body == "This is the main body")
 
         message = get_email('email_portuguese_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "Here is the actual email"
+        self.assertTrue(body == "Here is the actual email")
 
         message = get_email('email_portuguese_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body.startswith("This is a test")
-        assert body.endswith("This should be included")
+        self.assertTrue(body.startswith("This is a test"))
+        self.assertTrue(body.endswith("This should be included"))
 
         message = get_email('email_romanian_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "This is the actual email"
+        self.assertTrue(body == "This is the actual email")
 
         message = get_email('email_german_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body == "This is a german email"
+        self.assertTrue(body == "This is a german email")
 
     def test_sent_from_device_in_thread(self):
         """
@@ -275,7 +273,7 @@ class EmailMessageTest(unittest.TestCase):
         message = get_email("sent_from_device_in_thread")
         body = EmailReplyParser.cut_off_at_signature(message.text)
 
-        assert body == "Yes that would be fine"
+        self.assertTrue(body == "Yes that would be fine")
 
 
     def test_sent_from_device_in_thread_languages(self):
@@ -292,10 +290,10 @@ class EmailMessageTest(unittest.TestCase):
         body_dutch = EmailReplyParser.cut_off_at_signature(message_dutch.text)
         body_romanian = EmailReplyParser.cut_off_at_signature(message_romanian.text)
 
-        assert body_english == "Yes that would be fine"
-        assert body_hungarian == "Yes that would be fine"
-        assert body_dutch == "Yes that would be fine"
-        assert body_romanian == "Yes that would be fine"
+        self.assertTrue(body_english == "Yes that would be fine")
+        self.assertTrue(body_hungarian == "Yes that would be fine")
+        self.assertTrue(body_dutch == "Yes that would be fine")
+        self.assertTrue(body_romanian == "Yes that would be fine")
 
     def test_remove_non_alphabetic_signature_patter(self):
         """
@@ -304,21 +302,21 @@ class EmailMessageTest(unittest.TestCase):
 
         message_stars_signoff = get_email("email_with_stars_signoff")
         body = EmailReplyParser.cut_off_at_signature(message_stars_signoff.text)
-        assert body.endswith("Jim")
+        self.assertTrue(body.endswith("Jim"))
 
         message_dash_signoff = get_email("email_signature")
         body = EmailReplyParser.cut_off_at_signature(message_dash_signoff.text)
-        assert body.endswith("Perrin Aybara")
+        self.assertTrue(body.endswith("Perrin Aybara"))
 
         message_bullets = get_email("email_bullets")
         body = EmailReplyParser.cut_off_at_signature(message_bullets.text)
-        assert body.endswith("another")
+        self.assertTrue(body.endswith("another"))
 
     def test_remove_quoted_text(self):
         """Tests that we cut off an email correctly once we see quoted text '>'"""
         message = get_email("email_with_quoted_text")
         body = EmailReplyParser.cut_off_at_signature(message.text)
-        assert body.endswith("Tony")
+        self.assertTrue(body.endswith("Tony"))
 
     def test_spanish_signoff(self):
         """
@@ -326,7 +324,7 @@ class EmailMessageTest(unittest.TestCase):
         """
         message = get_email('spanish_signoff')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body.endswith('Salud')
+        self.assertTrue(body.endswith('Salud'))
 
     def test_remove_header_warnings(self):
         """
@@ -334,8 +332,8 @@ class EmailMessageTest(unittest.TestCase):
         """
         message = get_email('email_with_header_warning')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
-        assert body.startswith('Hi,')
-        assert body.endswith('Thanks')
+        self.assertTrue(body.startswith('Hi,'))
+        self.assertTrue(body.endswith('Thanks'))
 
 
     def test_dont_cut_signature_at_start_of_email(self):
@@ -349,10 +347,10 @@ class EmailMessageTest(unittest.TestCase):
         body_first_message = EmailReplyParser.cut_off_at_signature(first_message.text)
         body_second_message = EmailReplyParser.cut_off_at_signature(second_message.text)
 
-        assert body_first_message.startswith("Dear George Best,")
-        assert body_first_message.endswith("Phil")
-        assert body_second_message.startswith("Beste,")
-        assert body_second_message.endswith("Timmy")
+        self.assertTrue(body_first_message.startswith("Dear George Best,"))
+        self.assertTrue(body_first_message.endswith("Phil"))
+        self.assertTrue(body_second_message.startswith("Beste,"))
+        self.assertTrue(body_second_message.endswith("Timmy"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -13,6 +13,10 @@ def get_email(name):
     text = Path(f'emails/{name}.txt').read_text()
     return EmailReplyParser.read(text)
 
+def get_email_text(name):
+    """Return file text only"""
+    return Path(f'emails/{name}.txt').read_text()
+
 
 class EmailMessageTest(unittest.TestCase):
     def test_simple_body(self):
@@ -66,32 +70,33 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue(':+1:' in msg.fragments[0].content)
 
     def test_reply_from_gmail(self):
-        with open('emails/email_gmail.txt') as f:
-            self.assertEqual('This is a test for inbox replying to a github message.',
-                             EmailReplyParser.parse_reply(f.read()))
+        message = get_email_text('email_gmail')
+        EmailReplyParser.parse_reply(message)
 
     def test_parse_out_just_top_for_outlook_reply(self):
-        with open('emails/email_2_1.txt') as f:
-            self.assertEqual("Outlook with a reply", EmailReplyParser.parse_reply(f.read()))
+        message = get_email_text('email_2_1')
+        self.assertEqual("Outlook with a reply", EmailReplyParser.parse_reply(message))
 
     def test_parse_out_just_top_for_outlook_with_reply_directly_above_line(self):
-        with open('emails/email_2_2.txt') as f:
-            self.assertEqual("Outlook with a reply directly above line", EmailReplyParser.parse_reply(f.read()))
+        message = get_email_text('email_2_2')
+        self.assertEqual("Outlook with a reply directly above line", EmailReplyParser.parse_reply(message))
 
     def test_parse_out_just_top_for_outlook_with_unusual_headers_format(self):
-        with open('emails/email_2_3.txt') as f:
-            self.assertEqual(
-                "Outlook with a reply above headers using unusual format",
-                EmailReplyParser.parse_reply(f.read()))
+        message = get_email_text('email_2_3')
+        self.assertEqual(
+            "Outlook with a reply above headers using unusual format",
+            EmailReplyParser.parse_reply(message)
+        )
 
     def test_sent_from_iphone(self):
-        with open('emails/email_iPhone.txt') as email:
-            self.assertTrue("Sent from my iPhone" not in EmailReplyParser.parse_reply(email.read()))
+        message = get_email_text('email_iPhone')
+        self.assertTrue("Sent from my iPhone" not in EmailReplyParser.parse_reply(message))
 
     def test_email_one_is_not_on(self):
-        with open('emails/email_one_is_not_on.txt') as email:
-            self.assertTrue(
-                "On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(email.read()))
+        message = get_email_text('email_one_is_not_on')
+        self.assertTrue(
+            "On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(message)
+        )
 
     def test_partial_quote_header(self):
         message = get_email('email_partial_quote_header')
@@ -105,7 +110,7 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_pathological_emails(self):
         t0 = time.time()
-        message = get_email("pathological")
+        get_email("pathological")
         self.assertTrue(time.time() - t0 < 1, "Took too long")
 
     def test_doesnt_remove_signature_delimiter_in_mid_line(self):

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -2,9 +2,9 @@ import os
 import sys
 import unittest
 import time
-from email_reply_parser import EmailReplyParser
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from email_reply_parser import EmailReplyParser
 
 
 class EmailMessageTest(unittest.TestCase):
@@ -306,9 +306,9 @@ class EmailMessageTest(unittest.TestCase):
         body = EmailReplyParser.cut_off_at_signature(message_dash_signoff.text)
         assert body.endswith("Perrin Aybara")
 
-        message_bullets = self.get_email("email_with_bullets")
+        message_bullets = self.get_email("email_bullets")
         body = EmailReplyParser.cut_off_at_signature(message_bullets.text)
-        assert body.endswith("Jane")
+        assert body.endswith("another")
 
     def test_remove_quoted_text(self):
         """Tests that we cut off an email correctly once we see quoted text '>'"""

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -7,9 +7,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from email_reply_parser import EmailReplyParser
 
 
+def get_email(name):
+    """Return EmailMessage instance, utility function"""
+    with open('emails/%s.txt' % name) as f:
+        text = f.read()
+    return EmailReplyParser.read(text)
+
+
 class EmailMessageTest(unittest.TestCase):
     def test_simple_body(self):
-        message = self.get_email('email_1_1')
+        message = get_email('email_1_1')
 
         self.assertEqual(2, len(message.fragments))
         self.assertEqual(
@@ -24,17 +31,17 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue("riak-users" in message.fragments[1].content)
 
     def test_multiline_reply_headers(self):
-        message = self.get_email('email_1_6')
+        message = get_email('email_1_6')
         self.assertTrue('I get' in message.fragments[0].content)
         self.assertTrue('Sent' in message.fragments[1].content)
 
     def test_complex_body_with_one_fragment(self):
-        message = self.get_email('email_1_5')
+        message = get_email('email_1_5')
 
         self.assertEqual(1, len(message.fragments))
 
     def test_verify_reads_signature_correct(self):
-        message = self.get_email('correct_sig')
+        message = get_email('correct_sig')
         self.assertEqual(2, len(message.fragments))
 
         self.assertEqual(
@@ -55,7 +62,7 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue('--' in message.fragments[1].content)
 
     def test_deals_with_windows_line_endings(self):
-        msg = self.get_email('email_1_7')
+        msg = get_email('email_1_7')
         self.assertTrue(':+1:' in msg.fragments[0].content)
 
     def test_reply_from_gmail(self):
@@ -87,36 +94,29 @@ class EmailMessageTest(unittest.TestCase):
                 "On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(email.read()))
 
     def test_partial_quote_header(self):
-        message = self.get_email('email_partial_quote_header')
+        message = get_email('email_partial_quote_header')
         self.assertTrue("On your remote host you can run:" in message.reply)
         self.assertTrue("telnet 127.0.0.1 52698" in message.reply)
         self.assertTrue("This should connect to TextMate" in message.reply)
 
     def test_email_headers_no_delimiter(self):
-        message = self.get_email('email_headers_no_delimiter')
+        message = get_email('email_headers_no_delimiter')
         self.assertEqual(message.reply.strip(), 'And another reply!')
 
     def test_pathological_emails(self):
         t0 = time.time()
-        message = self.get_email("pathological")
+        message = get_email("pathological")
         self.assertTrue(time.time() - t0 < 1, "Took too long")
 
     def test_doesnt_remove_signature_delimiter_in_mid_line(self):
-        message = self.get_email('email_sig_delimiter_in_middle_of_line')
+        message = get_email('email_sig_delimiter_in_middle_of_line')
         self.assertEqual(1, len(message.fragments))
-
-    def get_email(self, name):
-        """ Return EmailMessage instance
-        """
-        with open('emails/%s.txt' % name) as f:
-            text = f.read()
-        return EmailReplyParser.read(text)
 
     def test_include_signature_true(self):
         # Test that the cut_off_at_signature function ends an email after the sign-off when include = True
-        message_english = self.get_email('email_signature')
-        message_german = self.get_email('email_german')
-        message_french = self.get_email('email_french')
+        message_english = get_email('email_signature')
+        message_german = get_email('email_german')
+        message_french = get_email('email_french')
 
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text, include=True, word_limit=100)
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=True, word_limit=100)
@@ -128,9 +128,9 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_include_signature_false(self):
         # Test that the cut_off_at_signature function ends an email before the sign-off when include = False
-        message_english = self.get_email('email_signature')
-        message_german = self.get_email('email_german')
-        message_french = self.get_email('email_french')
+        message_english = get_email('email_signature')
+        message_german = get_email('email_german')
+        message_french = get_email('email_french')
 
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text, include=False, word_limit=100)
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=False, word_limit=100)
@@ -142,7 +142,7 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_word_limit(self):
         # Test that a long email cuts off after the default or given word limit
-        message = self.get_email('long_passage')
+        message = get_email('long_passage')
         body_default_limit = EmailReplyParser.cut_off_at_signature(message.text, word_limit=100)  # Default value
         body_short = EmailReplyParser.cut_off_at_signature(message.text, word_limit=10)  # Less than default
         body_long = EmailReplyParser.cut_off_at_signature(message.text, word_limit=500)  # More than default
@@ -153,40 +153,40 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_clean_email_portuguese(self):
         # Test Portuguese regex
-        message = self.get_email('email_portuguese')
+        message = get_email('email_portuguese')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
         assert body.endswith("Cumprimentos\nPedro Mota")
 
     def test_clean_email_french(self):
         # Test Portuguese regex
-        message = self.get_email('email_french_accent_sent_on')
+        message = get_email('email_french_accent_sent_on')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=False, word_limit=100)
         assert body == "Bonjour, ca va bien!"
 
     def test_clean_email_content_no_change(self):
         # Ensure that a short email with no reply and no signature doesn't change
-        message = self.get_email('email_one_line')
+        message = get_email('email_one_line')
         clean_content = EmailReplyParser.cut_off_at_signature(body=message.text, word_limit=1000)
         self.assertEqual(message.text, clean_content)
 
     def test_end_of_email(self):
         # Check that an email that continues after the sign-off (without being a header or reply) cuts off at signature
-        message = self.get_email('email_continue_after_signoff')
+        message = get_email('email_continue_after_signoff')
         body = EmailReplyParser.cut_off_at_signature(message.text)
         assert body.endswith('Tom Bombadil')
 
     def test_keep_newlines_when_no_signoff(self):
         # Test that when there is no sign-off message detected at the end, the newlines/spacing are not changed
-        message = self.get_email('email_no_signature')
+        message = get_email('email_no_signature')
         body = EmailReplyParser.cut_off_at_signature(message.text)
         assert body.endswith("Let's see if it works.\n\nK")
 
     def test_remove_SIG_REGEX_end(self):
         # Test that any "Sent from iPhone" messages are removed at the end of an email
-        message_french = self.get_email('email_iphone_french')
-        message_portuguese = self.get_email('email_iphone_portuguese')
-        message_polish = self.get_email('email_iphone_polish')
-        message_finnish = self.get_email('email_iphone_finnish')
+        message_french = get_email('email_iphone_french')
+        message_portuguese = get_email('email_iphone_portuguese')
+        message_polish = get_email('email_iphone_polish')
+        message_finnish = get_email('email_iphone_finnish')
 
         body_french = EmailReplyParser.cut_off_at_signature(message_french.text)
         body_portuguese = EmailReplyParser.cut_off_at_signature(message_portuguese.text)
@@ -200,8 +200,8 @@ class EmailMessageTest(unittest.TestCase):
 
     def test_remove_SIG_REGEX_start(self):
         # Test that any "Sent from iPhone" messages are removed at the beginning of an email
-        message_english = self.get_email('email_iphone_start')
-        message_german = self.get_email('email_iphone_start_german')
+        message_english = get_email('email_iphone_start')
+        message_german = get_email('email_iphone_start_german')
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text)
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text)
         assert body_english.startswith('Hi,\n\nCase where the')
@@ -212,54 +212,54 @@ class EmailMessageTest(unittest.TestCase):
         """
         Tests that we are parsing out email response headers correctly for multiple languages
         """
-        message = self.get_email('email_polish_1')
+        message = get_email('email_polish_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "Ten tekst powinien pojawić się w treści"
 
-        message = self.get_email('email_polish_2')
+        message = get_email('email_polish_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "Ten tekst powinien pojawić się w treści"
 
-        message = self.get_email('email_polish_3')
+        message = get_email('email_polish_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "Ten tekst powinien pojawić się w treści"
 
-        message = self.get_email('email_polish_4')
+        message = get_email('email_polish_4')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "Ten tekst powinien pojawić się w treści"
 
-        message = self.get_email('email_greek_1')
+        message = get_email('email_greek_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body.endswith("Από τον Άδη")
 
-        message = self.get_email('email_malformed_thread_header')
+        message = get_email('email_malformed_thread_header')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
 
         assert body.endswith("que cet e-mail est analysé correctement")
 
-        message = self.get_email('email_with_two_headers')
+        message = get_email('email_with_two_headers')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
 
         assert body == "This is the main content"
 
-        message = self.get_email('email_portuguese_1')
+        message = get_email('email_portuguese_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "This is the main body"
 
-        message = self.get_email('email_portuguese_2')
+        message = get_email('email_portuguese_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "Here is the actual email"
 
-        message = self.get_email('email_portuguese_3')
+        message = get_email('email_portuguese_3')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body.startswith("This is a test")
         assert body.endswith("This should be included")
 
-        message = self.get_email('email_romanian_1')
+        message = get_email('email_romanian_1')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "This is the actual email"
 
-        message = self.get_email('email_german_2')
+        message = get_email('email_german_2')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body == "This is a german email"
 
@@ -267,7 +267,7 @@ class EmailMessageTest(unittest.TestCase):
         """
         Tests that if the thread becomes malformed we will be able to parse out the correct part if a sent from device is present
         """
-        message = self.get_email("sent_from_device_in_thread")
+        message = get_email("sent_from_device_in_thread")
         body = EmailReplyParser.cut_off_at_signature(message.text)
 
         assert body == "Yes that would be fine"
@@ -277,10 +277,10 @@ class EmailMessageTest(unittest.TestCase):
         """
         Tests that if the thread becomes malformed we will be able to parse out the correct part if a sent from device is present
         """
-        message_english = self.get_email("sent_from_device_in_thread_english")
-        message_hungarian = self.get_email("sent_from_device_in_thread_hungarian")
-        message_dutch = self.get_email("sent_from_device_in_thread_dutch")
-        message_romanian = self.get_email("sent_from_device_in_thread_romanian")
+        message_english = get_email("sent_from_device_in_thread_english")
+        message_hungarian = get_email("sent_from_device_in_thread_hungarian")
+        message_dutch = get_email("sent_from_device_in_thread_dutch")
+        message_romanian = get_email("sent_from_device_in_thread_romanian")
 
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text)
         body_hungarian = EmailReplyParser.cut_off_at_signature(message_hungarian.text)
@@ -297,21 +297,21 @@ class EmailMessageTest(unittest.TestCase):
         Tests that we we pick up things like --- and  * * * as signatures and ignore bullets
         """
 
-        message_stars_signoff = self.get_email("email_with_stars_signoff")
+        message_stars_signoff = get_email("email_with_stars_signoff")
         body = EmailReplyParser.cut_off_at_signature(message_stars_signoff.text)
         assert body.endswith("Jim")
 
-        message_dash_signoff = self.get_email("email_signature")
+        message_dash_signoff = get_email("email_signature")
         body = EmailReplyParser.cut_off_at_signature(message_dash_signoff.text)
         assert body.endswith("Perrin Aybara")
 
-        message_bullets = self.get_email("email_bullets")
+        message_bullets = get_email("email_bullets")
         body = EmailReplyParser.cut_off_at_signature(message_bullets.text)
         assert body.endswith("another")
 
     def test_remove_quoted_text(self):
         """Tests that we cut off an email correctly once we see quoted text '>'"""
-        message = self.get_email("email_with_quoted_text")
+        message = get_email("email_with_quoted_text")
         body = EmailReplyParser.cut_off_at_signature(message.text)
         assert body.endswith("Tony")
 
@@ -319,7 +319,7 @@ class EmailMessageTest(unittest.TestCase):
         """
         Tests that we're parsing the 'On Jan 31 X wrote:' correctly in Spanish.
         """
-        message = self.get_email('spanish_signoff')
+        message = get_email('spanish_signoff')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body.endswith('Salud')
 
@@ -327,7 +327,7 @@ class EmailMessageTest(unittest.TestCase):
         """
         Tests that we remove any warnings about external emails at the top of emails
         """
-        message = self.get_email('email_with_header_warning')
+        message = get_email('email_with_header_warning')
         body = EmailReplyParser.cut_off_at_signature(message.text, include=True)
         assert body.startswith('Hi,')
         assert body.endswith('Thanks')
@@ -338,8 +338,8 @@ class EmailMessageTest(unittest.TestCase):
         Some e-emails will start with things like "Dear Mr. Best,\n\nHow are you?" these can get parsed out at the end
         of an email unless handled correctly. This test just makes sure that we handle those correctly.
         """
-        first_message = self.get_email("george_best")
-        second_message = self.get_email("dutch_beste_example")
+        first_message = get_email("george_best")
+        second_message = get_email("dutch_beste_example")
 
         body_first_message = EmailReplyParser.cut_off_at_signature(first_message.text)
         body_second_message = EmailReplyParser.cut_off_at_signature(second_message.text)


### PR DESCRIPTION
# Changes
- Extracted utility function `get_email` outside test class and added new utility function: `get_email_text`
- Previously, there was a confusing mix between `self.assertTrue` and `assert` statements. Standardised all tests to the recommended `self.assertTrue`
- Used descriptive `assertEqual` and `assertIn` in correct circumstances
- Reordered methods into 2 groups: generic tests and language-specific tests
- Used dicts and for loops to simplify many, many lines of repetitive code