### PR TITLE
fix when we have more than one match

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -449,6 +449,7 @@ class EmailMessage(object):
 
         if len(signoff_matches_start_positions) > 0 and signoff_matches_start_positions[0] < len(body):
             # If a sign-off was found, cut-off email at starting position
+            # If there's one than more matches, go for the last one
             idx = 0 if len(signoff_matches) <= 1 else -1
             body = body[:signoff_matches_start_positions[idx]]
 

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -203,7 +203,7 @@ class EmailMessage(object):
         r"cordialement|très cordialement|bien cordialement|bien a vous|merci d'avance|d'avance merci|"
         r"Vielen Dank|Vielen Dank und LG|Herzliche Grusse|grussen\s?|grusse\s?|liebe Grusse\s?|"
         r"vielen dank im voraus|Mit freundlichen grussen|"
-        r"Mit freundlichen grüßen|Freundliche Grüße|"
+        r"Mit freundlichen grüßen|Freundliche Grüße|Freundliche Grusse|"
         r"saluti|Cordiali saluti|Distinti saluti|buona giornata|cordialmente|"
         r"o zi buna|o zi buna va urez|cu respect|cu stima|cu bine|toate cele bune|"
         r"saludos cordiales|atentamente|un saludo)(.{0,20})(,|\n))|"
@@ -449,7 +449,8 @@ class EmailMessage(object):
 
         if len(signoff_matches_start_positions) > 0 and signoff_matches_start_positions[0] < len(body):
             # If a sign-off was found, cut-off email at starting position
-            body = body[:signoff_matches_start_positions[0]]
+            idx = 0 if len(signoff_matches) <= 1 else -1
+            body = body[:signoff_matches_start_positions[idx]]
 
         else:
             # If no sign-off found, cut-off at word limit

--- a/test/emails/email_german_personio.txt
+++ b/test/emails/email_german_personio.txt
@@ -1,0 +1,14 @@
+Hallo Natalie,
+
+vielen Dank für Deine Anfrage.
+Ihr könnt die Gehälter auch vorher zuweisen. Das Ausschalten der Minusstunden dient allein dazu, dass in Personio für die Zeit ab Anstelldatum ohne Zeiterfassung keine Minusstunden aufgebaut werden.
+
+Freundliche Grüße
+Anke
+
+**Anke McElligott**,
+Implementation Specialist
+![Vereinfachte Zeiterfassung](https://cdn.bfldr.com/W4MMTT97/at/r6nbh5n35xwwcw9h86xf5m3/Time_DE.png?auto=webp&format=png)
+
+Willst du dir den Alltag leichter machen? Dann lerne jetzt unsere neuesten Funktionen kennen!
+Personio Webinare'

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -134,15 +134,18 @@ class EmailMessageTest(unittest.TestCase):
         # Test that the cut_off_at_signature function ends an email before the sign-off when include = False
         message_english = self.get_email('email_signature')
         message_german = self.get_email('email_german')
+        message_german_personio_sample = self.get_email('email_german_personio')
         message_french = self.get_email('email_french')
         # No Email signature for arabic because they are uncommon and not standard practise
 
         body_english = EmailReplyParser.cut_off_at_signature(message_english.text, include=False, word_limit=100)
         body_german = EmailReplyParser.cut_off_at_signature(message_german.text, include=False, word_limit=100)
+        body_german_personio = EmailReplyParser.cut_off_at_signature(message_german_personio_sample.text, include=False, word_limit=100)
         body_french = EmailReplyParser.cut_off_at_signature(message_french.text, include=False, word_limit=100)
 
         assert body_english.endswith('email cut-off point.')
         assert body_german.endswith('November vornehmen.')
+        assert body_german_personio.endswith('Zeiterfassung keine Minusstunden aufgebaut werden.')
         assert body_french.endswith("s'il vous plaît?")
 
     def test_word_limit(self):


### PR DESCRIPTION
There's one case where the signoff match, returns two elements instead of one.
What that causes is to split the email in the first match leaving the rest important part of the email behind.

This PR on top of adding another greeting in the regex, it chooses the last match if there are more than one.